### PR TITLE
Fix publishing package on GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ on:
   pull_request_target:
     types:
       - opened
-    paths:
-      - '**.ts'
-      - '**.json'
 name: Node.js CI
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ on:
   pull_request_target:
     types:
       - opened
+    paths-ignore:
+      - 'LICENSE'
+      - '.npmignore'
 name: Node.js CI
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,9 @@ jobs:
           registry-url: 'https://npm.pkg.github.com/'
           scope: '@tttaevas'
 
+      # See https://github.com/actions/setup-node/issues/156#issuecomment-803057923
+      - run: >
+          sed -i '/"license"/ i \\  "publishConfig": {\n    "registry": "https://npm.pkg.github.com/"\n \ },' package.json
       - run: yarn
       - run: yarn publish
         env:


### PR DESCRIPTION
According to issue 156 of setup-node, [I was unable to publish](https://github.com/TTTaevas/osu-api-v1-js/actions/runs/4227076947/jobs/7341185265) to GitHub Packages as it expects a `publishConfig.registry` in the `package.json` file
As I publish my package on both NPM and GPR through [./github/workflows/publish.yml](https://github.com/TTTaevas/osu-api-v1-js/blob/master/.github/workflows/publish.yml), changing my package.json directly in my repository did not feel like an appropriate solution
So, I've made it so when it tries to publish to GPR, it does a `sed` beforehand which adds the expected line in the package.json

also due to https://github.com/TTTaevas/osu-api-v1-js/pull/4/commits/133356bfc4035bf4ebdb22af3d13c28de5816465 I think I should have the tests run for *any* pr, shouldn't hurt