### PR TITLE
Make the `Score` interface more accurate

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -92,7 +92,7 @@ export class API {
 	 * @param user An Object with either a `user_id` or a `username`
 	 * @param mode The User's gamemode; 0: osu!, 1: taiko, 2: ctb, 3: mania
 	 * @param plays The User's top pp plays or the User's plays within the last 24 hours
-	 * @param limit The maximum number of scores to get, cannot exceed 100
+	 * @param limit The maximum number of scores to get, cannot exceed 100, defaults to 100
 	 * @returns A Promise with an array of Scores set by the User in a specific mode
 	 */
 	async getUserScores(user: {user_id?: number, username?: string} | User, mode: number, plays: "best" | "recent", limit?: number): Promise<Score[] | APIError> {
@@ -101,7 +101,7 @@ export class API {
 		if (!user.user_id && !user.username) {return new APIError("No proper `user` argument was given")}
 		let type = user.user_id ? "id" : "string"
 	
-		let response = await this.request(`get_user_${plays}`, `u=${type == "id" ? user.user_id : user.username}&type=${type}&m=${mode}&limit=${limit || 5}`)
+		let response = await this.request(`get_user_${plays}`, `u=${type == "id" ? user.user_id : user.username}&type=${type}&m=${mode}&limit=${limit || 100}`)
 		if (response) response.forEach((s: Object) => scores.push(correctType(s) as Score))
 		if (!scores.length) {return new APIError(`No Score could be found (user_id: ${user.user_id} | username: ${user.username})`)}
 	

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -152,9 +152,9 @@ export class API {
 	
 		if (user && !user.user_id && !user.username) {return new APIError("The `user` argument lacks a user_id/username property")}
 		let type = user ? user.user_id ? "id" : user.username ? "string" : false : false
-	
-		let response = await this.request("get_scores", `b=${diff_id}&m=${mode}${type ? type == "id" ? "&u="+user!.user_id : "&u="+user!.username : ""}
-		${mods ? "&mods="+mods : ""}${type ? "&type="+type : ""}&limit=${limit || 100}`)
+		let r_user = type ? type == "id" ? "&u="+user!.user_id : "&u="+user!.username : ""
+		
+		let response = await this.request("get_scores", `b=${diff_id}&m=${mode}${r_user}${mods ? "&mods="+mods : ""}${type ? "&type="+type : ""}&limit=${limit || 100}`)
 		if (response) response.forEach((s: Object) => scores.push(correctType(s) as Score))
 		if (!scores.length) {return new APIError(`No Score could be found (diff_id: ${diff_id})`)}
 	

--- a/lib/score.ts
+++ b/lib/score.ts
@@ -7,16 +7,31 @@ export interface Score {
 	count100: number
 	count300: number
 	countmiss: number
+	/**
+	 * https://osu.ppy.sh/wiki/en/Gameplay/Judgement/Katu
+	 */
 	countkatu: number
+	/**
+	 * https://osu.ppy.sh/wiki/en/Gameplay/Judgement/Geki
+	 */
 	countgeki: number
+	/**
+	 * Whether or not the play has reached the maximum combo it could have (no miss **and no missed slider-end**)
+	 */
 	perfect: boolean
 	/**
 	 * Bitwise flag. Feel free to use `getMods` to see the mods in a more readable way!
 	 */
 	enabled_mods: number
 	user_id: number
+	/**
+	 * Roughly (or just after) when the last note was hit
+	 */
 	date: Date
-	rank: number
+	/**
+	 * Also known as the Grade https://osu.ppy.sh/wiki/en/Gameplay/Grade, it may be "F" if the player failed
+	 */
+	rank: string
 	pp?: number
 	replay_available?: boolean
 }

--- a/lib/test.ts
+++ b/lib/test.ts
@@ -113,6 +113,24 @@ const test: () => Promise<void> = async () => {
 	process.stdout.write("Requesting scores from a bad Beatmap: ")
 	await api.getBeatmapScores(bad_id, 0)
 
+	const scores_limit = 10
+	process.stdout.write("\nRequesting the best scores of a normal User: ")
+	let u_scores1 = await api.getUserScores({user_id: 2}, 0, "best", scores_limit)
+	if (u_scores1 instanceof osu.APIError) {
+		throw new Error(`Got an APIError: ${u_scores1.message}`)
+	}
+	if (u_scores1.length !== scores_limit) {
+		throw new Error(`The array doesn't have a normal amount of scores!
+		Expected: ${scores_limit}
+		Got: ${u_scores1.length}`)
+	}
+	process.stdout.write("Requesting the best scores from a bad User: ")
+	await api.getUserScores({user_id: bad_id}, 0, "best", scores_limit)
+	process.stdout.write("Requesting the recent scores from a normal User: ")
+	await api.getUserScores({user_id: 2}, 0, "recent", scores_limit)
+	process.stdout.write("Requesting the recent scores from a bad User: ")
+	await api.getUserScores({user_id: bad_id}, 0, "recent", scores_limit)
+
 	console.log("\nLooks like the test went well!")
 }
 

--- a/lib/test.ts
+++ b/lib/test.ts
@@ -54,7 +54,6 @@ const test: () => Promise<void> = async () => {
 
 	// Check if getBeatmap() works fine
 	const song_name = "FriendZoned"
-
 	process.stdout.write("\nRequesting a normal Beatmap: ")
 	let b1 = await api.getBeatmap(m1.games[1].beatmap_id, 0)
 	if (b1 instanceof osu.APIError) {
@@ -99,6 +98,20 @@ const test: () => Promise<void> = async () => {
 			throw new Error(`Beatmaps with the mod ${value} have a difficultyrating of 0!`)
 		}
 	}
+
+	const score_amount = 132408001
+	process.stdout.write("\nRequesting scores from a normal Beatmap: ")
+	let b_scores = await api.getBeatmapScores(129891, 0, {user_id: 124493}, osu.Mods.Hidden + osu.Mods.HardRock)
+	if (b_scores instanceof osu.APIError) {
+		throw new Error(`Got an APIError: ${b_scores.message}`)
+	}
+	if (b_scores[0].score < score_amount) {
+		throw new Error(`The first score's amount is not what it should be!
+		Expected: ${score_amount} or more
+		Got: ${b_scores[0].score}`)
+	}
+	process.stdout.write("Requesting scores from a bad Beatmap: ")
+	await api.getBeatmapScores(bad_id, 0)
 
 	console.log("\nLooks like the test went well!")
 }


### PR DESCRIPTION
Prior to this PR, the interface had those issues:
- `perfect` was not a boolean
- `replay_available` was not a boolean
- `rank` had type number when it should have type string

Those issues are fixed with this PR, tests that use that interface have been added and more documentation has been written