### PR TITLE
Add/Edit enums, remove most object functions

### DIFF
--- a/lib/beatmap.ts
+++ b/lib/beatmap.ts
@@ -149,7 +149,7 @@ export interface Beatmap {
 }
 
 export const adjustBeatmapStatsToMods: (beatmap: Beatmap, mods: Mods) => Beatmap = (beatmap: Beatmap, mods: Mods) => {
-	const arr = getMods(mods, "short")
+	const arr = getMods(mods)
 	const convertARtoMS = (ar: number) => {
 		ar *= 10
 		let ms = 1800 // AR 0's ms
@@ -157,21 +157,21 @@ export const adjustBeatmapStatsToMods: (beatmap: Beatmap, mods: Mods) => Beatmap
 		return ms
 	}
 
-	if (arr.includes("EZ")) {
+	if (arr.includes("Easy")) {
 		beatmap.diff_size /= 2
 		beatmap.diff_approach /= 2
 		beatmap.diff_overall /= 2
 		beatmap.diff_drain /= 2
 	}
 
-	if (arr.includes("HR")) {
+	if (arr.includes("HardRock")) {
 		beatmap.diff_size = Math.min(10, beatmap.diff_size * 1.3)
 		beatmap.diff_approach = Math.min(10, beatmap.diff_approach * 1.4)
 		beatmap.diff_overall = Math.min(10, beatmap.diff_overall * 1.4)
 		beatmap.diff_drain = Math.min(10, beatmap.diff_drain * 1.4)
 	}
 
-	if (arr.includes("DT")) {
+	if (arr.includes("DoubleTime") || arr.includes("Nightcore")) {
 		beatmap.total_length /= 1.5
 		beatmap.hit_length /= 1.5
 		beatmap.bpm *= 1.5
@@ -179,7 +179,7 @@ export const adjustBeatmapStatsToMods: (beatmap: Beatmap, mods: Mods) => Beatmap
 		beatmap.diff_overall = (80 - ((80 - 6 * beatmap.diff_overall) / 1.5)) / 6
 	}
 
-	if (arr.includes("HT")) {
+	if (arr.includes("HalfTime")) {
 		beatmap.total_length /= 0.75
 		beatmap.hit_length /= 0.75
 		beatmap.bpm *= 0.75

--- a/lib/beatmap.ts
+++ b/lib/beatmap.ts
@@ -93,6 +93,9 @@ export interface Beatmap {
 	 * Health Drain https://osu.ppy.sh/wiki/en/Gameplay/Health
 	 */
 	diff_drain: number
+	/**
+	 * The number representing the Gamemode for which the API responsed (it may not be the requested Gamemode if the beatmap is exclusive to Taiko/CTB/Mania)
+	 */
 	mode: number
 	count_normal: number
 	count_slider: number

--- a/lib/beatmap.ts
+++ b/lib/beatmap.ts
@@ -1,57 +1,57 @@
 import { getMods, Mods } from "./index"
 
 /**
- * For the `approved` of Beatmaps https://osu.ppy.sh/wiki/en/Beatmap/Category
+ * For the `approved` of a `Beatmap` (for example, `Categories[beatmap.approved]` would return "RANKED" if 1) https://osu.ppy.sh/wiki/en/Beatmap/Category
  */
 export enum Categories {
-	graveyard = -2,
+	GRAVEYARD = -2,
 	WIP  			= -1,
-	pending 	= 0,
-	ranked  	= 1,
-	approved 	= 2,
-	qualified = 3,
+	PENDING 	= 0,
+	RANKED  	= 1,
+	APPROVED 	= 2,
+	QUALIFIED = 3,
 }
 
 /**
- * For the `genre_id` of Beatmaps
+ * For the `genre_id` of a `Beatmap` (for example, `Genres[beatmap.genre_id]` would return "NOVELTY" if 7)
  */
 export enum Genres {
-	any 				 = 0,
-	unspecified  = 1,
-	"video game" = 2,
-	anime 			 = 3,
-	rock 				 = 4,
-	pop 				 = 5,
-	other 			 = 6,
-	novelty 		 = 7,
+	ANY 				 = 0,
+	UNSPECIFIED  = 1,
+	"VIDEO GAME" = 2,
+	ANIME 			 = 3,
+	ROCK 				 = 4,
+	POP 				 = 5,
+	OTHER 			 = 6,
+	NOVELTY 		 = 7,
 	"" 					 = 8,
-	"hip hop" 	 = 9,
-	electronic 	 = 10,
-	metal 			 = 11,
-	classical 	 = 12,
-	folk 				 = 13,
-	jazz 				 = 14,
+	"HIP HOP" 	 = 9,
+	ELECTRONIC 	 = 10,
+	METAL 			 = 11,
+	CLASSICAL 	 = 12,
+	FOLK 				 = 13,
+	JAZZ 				 = 14,
 }
 
 /**
- * For the `language_id` of Beatmaps
+ * For the `language_id` of a `Beatmap` (for example, `Languages[beatmap.language_id]` would return "FRENCH" if 7)
  */
 export enum Languages {
-	any 				 = 0,
-	unspecified  = 1,
-	english 		 = 2,
-	japanese 		 = 3,
-	chinese 		 = 4,
-	instrumental = 5,
-	korean 			 = 6,
-	french 			 = 7,
-	german 			 = 8,
-	swedish 		 = 9,
-	spanish 		 = 10,
-	italian 		 = 11,
-	russian 		 = 12,
-	polish 			 = 13,
-	other 			 = 14,
+	ANY 				 = 0,
+	UNSPECIFIED  = 1,
+	ENGLISH 		 = 2,
+	JAPANESE 		 = 3,
+	CHINESE 		 = 4,
+	INSTRUMENTAL = 5,
+	KOREAN 			 = 6,
+	FRENCH 			 = 7,
+	GERMAN 			 = 8,
+	SWEDISH 		 = 9,
+	SPANISH 		 = 10,
+	ITALIAN 		 = 11,
+	RUSSIAN 		 = 12,
+	POLISH 			 = 13,
+	OTHER 			 = 14,
 }
 
 export interface Beatmap {
@@ -146,9 +146,6 @@ export interface Beatmap {
 	 */
 	difficultyrating: number
 	getLength: Function
-	getCategory: Function
-	getGenre: Function
-	getLanguage: Function
 }
 
 export const adjustBeatmapStatsToMods: (beatmap: Beatmap, mods: Mods) => Beatmap = (beatmap: Beatmap, mods: Mods) => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,9 +3,9 @@ import { User } from "./user"
 import { Score } from "./score"
 import { adjustBeatmapStatsToMods, Beatmap, Categories, Genres, Languages } from "./beatmap"
 import { Match } from "./match"
-import { Mods, ModsShort, unsupported_mods } from "./mods"
+import { Mods, unsupported_mods } from "./mods"
 
-export {User, Score, Match, Mods, ModsShort}
+export {User, Score, Match, Mods}
 export {Beatmap, Categories, Genres, Languages, adjustBeatmapStatsToMods}
 
 export class APIError {
@@ -115,8 +115,8 @@ export class API {
 	 */
 	async getBeatmap(diff_id: number, mods?: Mods): Promise<Beatmap | APIError> {
 		if (mods === undefined) {mods = Mods.None}
-		unsupported_mods.forEach((mod) => getMods(mods!, "long").includes(Mods[mod]) ? mods! -= mod : mods! -= 0)
-		if (getMods(mods, "long").includes(Mods[Mods.Nightcore])) {mods -= Mods.Nightcore - Mods.DoubleTime}
+		unsupported_mods.forEach((mod) => getMods(mods!).includes(Mods[mod]) ? mods! -= mod : mods! -= 0)
+		if (getMods(mods).includes(Mods[Mods.Nightcore])) {mods -= Mods.Nightcore - Mods.DoubleTime}
 	
 		let response = await this.request("get_beatmaps", `b=${diff_id}&mods=${mods}`)
 		if (!response[0]) {return new APIError(`No Beatmap could be found (diff_id: ${diff_id})`)}
@@ -145,7 +145,7 @@ export class API {
 	 * @param limit The maximum number of `Scores` to get, cannot exceed 100, defaults to 100
 	 * @returns A Promise with an array of `Scores` set on a beatmap
 	 */
-	async getBeatmapScores(diff_id: number, mode: Gamemodes, user?: {user_id?: number, username?: string} | User, mods?: ModsShort, limit?: number): Promise<Score[] | APIError> {
+	async getBeatmapScores(diff_id: number, mode: Gamemodes, user?: {user_id?: number, username?: string} | User, mods?: Mods, limit?: number): Promise<Score[] | APIError> {
 		let scores: Score[] = []
 	
 		if (user && !user.user_id && !user.username) {return new APIError("The `user` argument lacks a user_id/username property")}
@@ -214,17 +214,12 @@ export enum WinConditions {
 
 /**
  * @param value A number representing the `Mods`
- * @param version Whether the `Mods` are shown respectively like `["HD", "HR"]` or `["Hidden", "HardRock"]`
  * @returns An Array of Strings, each string representing a mod
  */
-export function getMods(value: Mods | ModsShort, version: "short" | "long"): string[] {
+export function getMods(value: Mods): string[] {
 	let arr: string[] = []
 	for (let bit = 1; bit != 0; bit <<= 1) { 
-		if (version == "short") {
-			if ((value & bit) != 0 && bit in ModsShort) {arr.push(ModsShort[bit])}
-		} else {
-			if ((value & bit) != 0 && bit in Mods) {arr.push(Mods[bit])}
-		}
+		if ((value & bit) != 0 && bit in Mods) {arr.push(Mods[bit])}
 	}
 	return arr
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -166,11 +166,6 @@ export class API {
 	async getMatch(id: number): Promise<Match | APIError> {
 		let response = await this.request("get_match", `mp=${id}`)
 		if (!response.match) {return new APIError(`No Match could be found (id: ${id})`)}
-		response.games.forEach((g: any) => {
-			g.getScoringType = () => {
-				return ["score", "accuracy", "combo", "scorev2"][g.scoring_type]
-			}
-		})
 		return correctType(response) as Match
 	}
 }
@@ -194,7 +189,27 @@ export enum Gamemodes {
 	/**
 	 * https://osu.ppy.sh/wiki/en/Game_mode/osu!mania
 	 */
-	MANIA = 3
+	MANIA = 3,
+}
+
+/**
+ * https://osu.ppy.sh/wiki/en/Client/Interface/Multiplayer#team-mode-gameplay
+ */
+export enum MultiplayerModes {
+	"HEAD TO HEAD" = 0,
+	"TAG CO-OP" 	 = 1,
+	"TEAM VS" 		 = 2,
+	"TAG TEAM VS"  = 3,
+}
+
+/**
+ * https://osu.ppy.sh/wiki/en/Client/Interface/Multiplayer#win-condition
+ */
+export enum WinConditions {
+	SCORE 		 = 0,
+	ACCURACY 	 = 1,
+	COMBO 		 = 2,
+	"SCORE V2" = 3,
 }
 
 /**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -133,9 +133,6 @@ export class API {
 			
 			return `${m}:${s}`
 		}
-		beatmap.getCategory = () => {return Categories[beatmap.approved]}
-		beatmap.getGenre = () => {return Genres[beatmap.genre_id]}
-		beatmap.getLanguage = () => {return Languages[beatmap.language_id]}
 
 		return beatmap
 	}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -76,10 +76,10 @@ export class API {
 
 	/**
 	 * @param search An Object with either a `user_id` or a `username` (ignores `username` if `user_id` is specified)
-	 * @param mode The User's gamemode; 0: osu!, 1: taiko, 2: ctb, 3: mania
-	 * @returns A Promise with a User found with the search
+	 * @param mode The `User`'s `Gamemode`
+	 * @returns A Promise with a `User` found with the search
 	 */
-	async getUser(search: {user_id?: number, username?: string} | User, mode: number): Promise<User | APIError> {
+	async getUser(search: {user_id?: number, username?: string} | User, mode: Gamemodes): Promise<User | APIError> {
 		if (!search.user_id && !search.username) {return new APIError("No proper `search` argument was given")}
 		let type = search.user_id ? "id" : "string"
 	
@@ -90,12 +90,12 @@ export class API {
 
 	/**
 	 * @param user An Object with either a `user_id` or a `username`
-	 * @param mode The User's gamemode; 0: osu!, 1: taiko, 2: ctb, 3: mania
-	 * @param plays The User's top pp plays or the User's plays within the last 24 hours
-	 * @param limit The maximum number of scores to get, cannot exceed 100, defaults to 100
-	 * @returns A Promise with an array of Scores set by the User in a specific mode
+	 * @param mode The `User`'s `Gamemode`
+	 * @param plays The `User`'s top pp plays/`Scores` or the `User`'s plays/`Scores` within the last 24 hours
+	 * @param limit The maximum number of Scores to get, cannot exceed 100, defaults to 100
+	 * @returns A Promise with an array of `Scores` set by the `User` in a specific `Gamemode`
 	 */
-	async getUserScores(user: {user_id?: number, username?: string} | User, mode: number, plays: "best" | "recent", limit?: number): Promise<Score[] | APIError> {
+	async getUserScores(user: {user_id?: number, username?: string} | User, mode: Gamemodes, plays: "best" | "recent", limit?: number): Promise<Score[] | APIError> {
 		let scores: Score[] = []
 	
 		if (!user.user_id && !user.username) {return new APIError("No proper `user` argument was given")}
@@ -109,12 +109,13 @@ export class API {
 	}
 
 	/**
-	 * @param diff_id The ID of the difficulty/beatmap of the beatmapset
-	 * @param mods A number representing the mods to apply
-	 * @returns A Promise with a Beatmap
+	 * @param diff_id The ID of the difficulty/`Beatmap` of the beatmapset
+	 * @param mods A number representing the `Mods` to apply, defaults to 0 (no mod)
+	 * @returns A Promise with a `Beatmap`
 	 */
-	async getBeatmap(diff_id: number, mods: Mods): Promise<Beatmap | APIError> {
-		unsupported_mods.forEach((mod) => getMods(mods, "long").includes(Mods[mod]) ? mods -= mod : mods -= 0)
+	async getBeatmap(diff_id: number, mods?: Mods): Promise<Beatmap | APIError> {
+		if (mods === undefined) {mods = Mods.None}
+		unsupported_mods.forEach((mod) => getMods(mods!, "long").includes(Mods[mod]) ? mods! -= mod : mods! -= 0)
 		if (getMods(mods, "long").includes(Mods[Mods.Nightcore])) {mods -= Mods.Nightcore - Mods.DoubleTime}
 	
 		let response = await this.request("get_beatmaps", `b=${diff_id}&mods=${mods}`)
@@ -141,13 +142,13 @@ export class API {
 
 	/**
 	 * @param diff_id The ID of the difficulty/beatmap of the beatmapset
-	 * @param mode The Scores' gamemode; 0: osu!, 1: taiko, 2: ctb, 3: mania
-	 * @param user The Scores' user, which is an Object with either a `user_id` or a `username`
-	 * @param mods A number representing the mods to apply, defaults to 0 (no mod)
-	 * @param limit The maximum number of scores to get, cannot exceed 100, defaults to 100
-	 * @returns A Promise with an array of Scores set on a beatmap
+	 * @param mode A number representing the `Scores`' `Gamemode`
+	 * @param user The `Scores`' user, which is an Object with either a `user_id` or a `username`
+	 * @param mods A number representing the `Mods` to apply, defaults to 0 (no mod)
+	 * @param limit The maximum number of `Scores` to get, cannot exceed 100, defaults to 100
+	 * @returns A Promise with an array of `Scores` set on a beatmap
 	 */
-	async getBeatmapScores(diff_id: number, mode: number, user?: {user_id?: number, username?: string} | User, mods?: ModsShort, limit?: number): Promise<Score[] | APIError> {
+	async getBeatmapScores(diff_id: number, mode: Gamemodes, user?: {user_id?: number, username?: string} | User, mods?: ModsShort, limit?: number): Promise<Score[] | APIError> {
 		let scores: Score[] = []
 	
 		if (user && !user.user_id && !user.username) {return new APIError("The `user` argument lacks a user_id/username property")}
@@ -162,8 +163,8 @@ export class API {
 	}
 
 	/**
-	 * @param id The ID of the match
-	 * @returns A Promise with a Match
+	 * @param id The ID of the `Match`
+	 * @returns A Promise with a `Match`
 	 */
 	async getMatch(id: number): Promise<Match | APIError> {
 		let response = await this.request("get_match", `mp=${id}`)
@@ -178,16 +179,30 @@ export class API {
 }
 
 /**
- * @param id The ID of the gamemode (should be from 0 to 3)
- * @returns A text version of the gamemode
+ * https://osu.ppy.sh/wiki/en/Game_mode
  */
-export function getMode(id: number): string {
-	return ["osu!", "taiko", "catch the beat", "osu!mania"][id]
+export enum Gamemodes {
+	/**
+	 * https://osu.ppy.sh/wiki/en/Game_mode/osu!
+	 */
+	OSU 	= 0,
+	/**
+	 * https://osu.ppy.sh/wiki/en/Game_mode/osu!taiko
+	 */
+	TAIKO = 1,
+	/**
+	 * https://osu.ppy.sh/wiki/en/Game_mode/osu!catch
+	 */
+	CTB 	= 2,
+	/**
+	 * https://osu.ppy.sh/wiki/en/Game_mode/osu!mania
+	 */
+	MANIA = 3
 }
 
 /**
- * @param value A number representing the mods to apply
- * @param version Whether the mods are shown respectively like `["HD", "HR"]` or `["Hidden", "HardRock"]`
+ * @param value A number representing the `Mods`
+ * @param version Whether the `Mods` are shown respectively like `["HD", "HR"]` or `["Hidden", "HardRock"]`
  * @returns An Array of Strings, each string representing a mod
  */
 export function getMods(value: Mods | ModsShort, version: "short" | "long"): string[] {

--- a/lib/match.ts
+++ b/lib/match.ts
@@ -56,6 +56,5 @@ export interface Match {
 			 */
 			enabled_mods: number | null
 		}[]
-		getScoringType: Function
 	}[]
 }

--- a/lib/mods.ts
+++ b/lib/mods.ts
@@ -36,44 +36,6 @@ export enum Mods { // Directly taken from https://github.com/ppy/osu-api/wiki
 	// ScoreIncreaseMods = Hidden | HardRock | DoubleTime | Flashlight | FadeIn
 }
 
-export enum ModsShort {
-	NM    = 0,
-	NF    = 1,
-	EZ    = 2,
-	TD    = 4,
-	HD    = 8,
-	HR    = 16,
-	SD    = 32,
-	DT    = 64,
-	RX    = 128,
-	HT    = 256, 
-	NC    = 512, // Only set along with DoubleTime. i.e: NC only gives 576
-	FL    = 1024,
-	AT    = 2048,
-	SO    = 4096,
-	AP    = 8192, // Is "Relax2" in documentation
-	PF    = 16384, // Only set along with SuddenDeath. i.e: PF only gives 16416  
-	Key4           = 32768, // I'll do that part when I feel like looking into mania stuff ig
-	Key5           = 65536,
-	Key6           = 131072,
-	Key7           = 262144,
-	Key8           = 524288,
-	FadeIn         = 1048576,
-	Random         = 2097152,
-	Cinema         = 4194304,
-	Target         = 8388608,
-	Key9           = 16777216,
-	KeyCoop        = 33554432,
-	Key1           = 67108864,
-	Key3           = 134217728,
-	Key2           = 268435456,
-	ScoreV2        = 536870912,
-	Mirror         = 1073741824,
-	// KeyMod = Key1 | Key2 | Key3 | Key4 | Key5 | Key6 | Key7 | Key8 | Key9 | KeyCoop,
-	// FreeModAllowed = NF | EZ | HD | HR | SD | FL | FadeIn | RX | AP | SO | KeyMod,
-	// ScoreIncreaseMods = HD | HR | DT | FL | FadeIn
-}
-
 /**
  * API returns the SR (and pp stuff) of a Beatmap as 0/null if any of those mods are included.
  * Nightcore would also be featured in this Array, but getBeatmap() circumvents that issue by converting it to DoubleTime!

--- a/lib/test.ts
+++ b/lib/test.ts
@@ -25,7 +25,7 @@ const test: () => Promise<void> = async () => {
 	// Check if getUser() works fine
 	const user_id = 7276846
 	process.stdout.write("\nRequesting a normal User: ")
-	let u1 = await api.getUser({user_id}, 0)
+	let u1 = await api.getUser({user_id}, osu.Gamemodes.OSU)
 	if (u1 instanceof osu.APIError) {
 		throw new Error(`Got an APIError: ${u1.message}`)
 	}
@@ -35,7 +35,7 @@ const test: () => Promise<void> = async () => {
 		Got: ${u1.user_id}`)
 	}
 	process.stdout.write("Requesting a bad User: ")
-	await api.getUser({user_id: bad_id}, 3)
+	await api.getUser({user_id: bad_id}, osu.Gamemodes.MANIA)
 
 	// Check if getMatch() works fine
 	const match_name = "IT: (tout le monde) vs (Adéquat feur)"
@@ -55,7 +55,7 @@ const test: () => Promise<void> = async () => {
 	// Check if getBeatmap() works fine
 	const song_name = "FriendZoned"
 	process.stdout.write("\nRequesting a normal Beatmap: ")
-	let b1 = await api.getBeatmap(m1.games[1].beatmap_id, 0)
+	let b1 = await api.getBeatmap(m1.games[1].beatmap_id)
 	if (b1 instanceof osu.APIError) {
 		throw new Error(`Got an APIError: ${b1.message}`)
 	}
@@ -65,7 +65,7 @@ const test: () => Promise<void> = async () => {
 		Got: ${b1.title}`)
 	}
 	process.stdout.write("Requesting a bad Beatmap: ")
-	await api.getBeatmap(bad_id, 0)
+	await api.getBeatmap(bad_id)
 
 	process.stdout.write("\nRequesting another normal Beatmap once in order to change its stats with mods: ")
 	let b2 = await api.getBeatmap(2592029, osu.Mods.NoFail)
@@ -101,7 +101,7 @@ const test: () => Promise<void> = async () => {
 
 	const score_amount = 132408001
 	process.stdout.write("\nRequesting scores from a normal Beatmap: ")
-	let b_scores = await api.getBeatmapScores(129891, 0, {user_id: 124493}, osu.Mods.Hidden + osu.Mods.HardRock)
+	let b_scores = await api.getBeatmapScores(129891, osu.Gamemodes.OSU, {user_id: 124493}, osu.Mods.Hidden + osu.Mods.HardRock)
 	if (b_scores instanceof osu.APIError) {
 		throw new Error(`Got an APIError: ${b_scores.message}`)
 	}
@@ -111,11 +111,11 @@ const test: () => Promise<void> = async () => {
 		Got: ${b_scores[0].score}`)
 	}
 	process.stdout.write("Requesting scores from a bad Beatmap: ")
-	await api.getBeatmapScores(bad_id, 0)
+	await api.getBeatmapScores(bad_id, osu.Gamemodes.OSU)
 
 	const scores_limit = 10
 	process.stdout.write("\nRequesting the best scores of a normal User: ")
-	let u_scores1 = await api.getUserScores({user_id: 2}, 0, "best", scores_limit)
+	let u_scores1 = await api.getUserScores({user_id: 2}, osu.Gamemodes.OSU, "best", scores_limit)
 	if (u_scores1 instanceof osu.APIError) {
 		throw new Error(`Got an APIError: ${u_scores1.message}`)
 	}
@@ -125,11 +125,11 @@ const test: () => Promise<void> = async () => {
 		Got: ${u_scores1.length}`)
 	}
 	process.stdout.write("Requesting the best scores from a bad User: ")
-	await api.getUserScores({user_id: bad_id}, 0, "best", scores_limit)
+	await api.getUserScores({user_id: bad_id}, osu.Gamemodes.TAIKO, "best", scores_limit)
 	process.stdout.write("Requesting the recent scores from a normal User: ")
-	await api.getUserScores({user_id: 2}, 0, "recent", scores_limit)
+	await api.getUserScores({user_id: 2}, osu.Gamemodes.CTB, "recent", scores_limit)
 	process.stdout.write("Requesting the recent scores from a bad User: ")
-	await api.getUserScores({user_id: bad_id}, 0, "recent", scores_limit)
+	await api.getUserScores({user_id: bad_id}, osu.Gamemodes.MANIA, "recent", scores_limit)
 
 	console.log("\nLooks like the test went well!")
 }

--- a/lib/test.ts
+++ b/lib/test.ts
@@ -72,12 +72,13 @@ const test: () => Promise<void> = async () => {
 	if (b2 instanceof osu.APIError) {throw new Error(`Got an APIError: ${b2.message}`)}
 	// Expected AR is specified on: https://osu.ppy.sh/wiki/en/Beatmap/Approach_rate#table-comparison
 	// Expected OD is specified on: https://osu.ppy.sh/wiki/en/Beatmap/Overall_difficulty#osu!
-	testBeatmapWithMods(b2, osu.Mods.DoubleTime, {bpm: 294, cs: 3, ar: 9, od: 8.44, hp: 4})
+	const dtnc = [osu.Mods.DoubleTime, osu.Mods.Nightcore]
+	for (let i=0;i<dtnc.length;i++) {testBeatmapWithMods(b2, dtnc[i], {bpm: 294, cs: 3, ar: 9, od: 8.44, hp: 4})}
 	testBeatmapWithMods(b2, osu.Mods.HalfTime, {bpm: 147, cs: 3, ar: 5, od: 3.56, hp: 4})
 	testBeatmapWithMods(b2, osu.Mods.Easy, {bpm: 196, cs: 1.5, ar: 3.5, od: 3, hp: 2})
 	testBeatmapWithMods(b2, osu.Mods.HardRock, {bpm: 196, cs: 3.9, ar: 9.8, od: 8.4, hp: 5.6})
-	testBeatmapWithMods(b2, osu.Mods.DoubleTime + osu.Mods.Easy, {bpm: 294, cs: 1.5, ar: 6.87, od: 6.44, hp: 2})
-	testBeatmapWithMods(b2, osu.Mods.DoubleTime + osu.Mods.HardRock, {bpm: 294, cs: 3.9, ar: 10.87, od: 10.04, hp: 5.6})
+	for (let i=0;i<dtnc.length;i++) {testBeatmapWithMods(b2, dtnc[i] + osu.Mods.Easy, {bpm: 294, cs: 1.5, ar: 6.87, od: 6.44, hp: 2})}
+	for (let i=0;i<dtnc.length;i++) {testBeatmapWithMods(b2, dtnc[i] + osu.Mods.HardRock, {bpm: 294, cs: 3.9, ar: 10.87, od: 10.04, hp: 5.6})}
 	testBeatmapWithMods(b2, osu.Mods.HalfTime + osu.Mods.Easy, {bpm: 147, cs: 1.5, ar: -0.33, od: -0.44, hp: 2})
 	testBeatmapWithMods(b2, osu.Mods.HalfTime + osu.Mods.HardRock, {bpm: 147, cs: 3.9, ar: 8.73, od: 6.76, hp: 5.6})
 
@@ -87,7 +88,7 @@ const test: () => Promise<void> = async () => {
 		// So if we were to request a beatmap with such a mod here, we'd be requesting it with NM instead
 		// I honestly just don't wanna make the same request in a row ~15 times :skull:
 		if (unsupported_mods.includes(Number(key))) {
-			console.log("The following mod will not be requested as it'd be pointless:", osu.getMods(Number(key), "long"))
+			console.log("The following mod will not be requested as it'd be pointless:", osu.getMods(Number(key)))
 			continue
 		}
 		
@@ -145,9 +146,9 @@ const testBeatmapWithMods = (b: osu.Beatmap, mods: osu.Mods, expected: object) =
 	}
 	if (JSON.stringify(stats) !== JSON.stringify(expected)) {
 		console.log("Expected", expected, "but got", stats)
-		throw new Error(`The beatmap's stats with the mods ${osu.getMods(mods, "long")} are not what they should be!`)
+		throw new Error(`The beatmap's stats with the mods ${osu.getMods(mods)} are not what they should be!`)
 	} else {
-		console.log(osu.getMods(mods, "long"), "Beatmaps' stats are looking good!")
+		console.log(osu.getMods(mods), "Beatmaps' stats are looking good!")
 	}
 }
 


### PR DESCRIPTION
Cleaner that way, win condition wasn't even properly supported yet
Beatmap's getLength felt out of the scope of this PR because no enum to replace it with, but it will get changed in some way before v0.4.0