### PR TITLE
Change `getBeatmap` and `getReplay`, create `getBeatmaps`

### DIFF
--- a/lib/test.ts
+++ b/lib/test.ts
@@ -55,7 +55,7 @@ const test: () => Promise<void> = async () => {
 	// Check if getBeatmap() works fine
 	const song_name = "FriendZoned"
 	process.stdout.write("\nRequesting a normal Beatmap: ")
-	let b1 = await api.getBeatmap(m1.games[1].beatmap_id)
+	let b1 = await api.getBeatmap({beatmap_id: m1.games[1].beatmap_id})
 	if (b1 instanceof osu.APIError) {
 		throw new Error(`Got an APIError: ${b1.message}`)
 	}
@@ -65,10 +65,10 @@ const test: () => Promise<void> = async () => {
 		Got: ${b1.title}`)
 	}
 	process.stdout.write("Requesting a bad Beatmap: ")
-	await api.getBeatmap(bad_id)
+	await api.getBeatmap({beatmap_id: bad_id})
 
 	process.stdout.write("\nRequesting another normal Beatmap once in order to change its stats with mods: ")
-	let b2 = await api.getBeatmap(2592029, osu.Mods.NoFail)
+	let b2 = await api.getBeatmap({beatmap_id: 2592029}, osu.Mods.NoFail)
 	if (b2 instanceof osu.APIError) {throw new Error(`Got an APIError: ${b2.message}`)}
 	// Expected AR is specified on: https://osu.ppy.sh/wiki/en/Beatmap/Approach_rate#table-comparison
 	// Expected OD is specified on: https://osu.ppy.sh/wiki/en/Beatmap/Overall_difficulty#osu!
@@ -93,7 +93,7 @@ const test: () => Promise<void> = async () => {
 		}
 		
 		process.stdout.write(`Requesting SR of Beatmap with mod ${value}: `)
-		let b3 = await api.getBeatmap(2592029, Number(key))
+		let b3 = await api.getBeatmap(b2, Number(key))
 		if (b3 instanceof osu.APIError) {throw new Error(`Got an APIError: ${b3.message}`)}
 		if (b3.difficultyrating === 0) {
 			throw new Error(`Beatmaps with the mod ${value} have a difficultyrating of 0!`)

--- a/lib/test.ts
+++ b/lib/test.ts
@@ -135,7 +135,7 @@ const test: () => Promise<void> = async () => {
 	// Check if getReplay() works fine
 	const replay_id = 2177560145
 	process.stdout.write("\nRequesting the Replay from a normal score: ")
-	let replay = await api.getReplay({id: replay_id}, osu.Gamemodes.OSU)
+	let replay = await api.getReplay(osu.Gamemodes.OSU, {score_id: replay_id})
 	if (replay instanceof osu.APIError) {
 		throw new Error(`Got an APIError: ${replay.message}`)
 	}
@@ -145,7 +145,7 @@ const test: () => Promise<void> = async () => {
 		Got: ${replay.content.length}`)
 	}
 	process.stdout.write("Requesting the Replay from a bad score: ")
-	await api.getReplay({id: bad_id}, osu.Gamemodes.TAIKO, osu.Mods.Autopilot)
+	await api.getReplay(osu.Gamemodes.TAIKO, {score_id: bad_id})
 
 	console.log("\nLooks like the test went well!")
 }


### PR DESCRIPTION
Using getReplay should feel better now
I initially planned to get rid of getBeatmap in favour of getBeatmap**s**, but its simplicity makes it so it's worth to keep it around
Nonetheless, getBeatmap works slightly differently and now supports converting osu! maps to taiko/ctb/mania (which changes the maxcombo and pp/difficulty-related stuff (which I've learned just now can be null in those mods, fuck))